### PR TITLE
Suggesting changes to CoC guidelines language

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,10 +2,10 @@
 title: "Contributor Code of Conduct"
 ---
 As contributors and maintainers of this project,
-we pledge to follow the [Carpentry Code of Conduct][coc].
+we pledge to follow the [The Carpentries Code of Conduct][coc].
 
-Instances of abusive, harassing, or otherwise unacceptable behavior
-may be reported by following our [reporting guidelines][coc-reporting].
+If this lesson is being taught as a registered Carpentries workshop, instances of abusive, harassing, or otherwise unacceptable behavior
+may be reported by following their [reporting guidelines][coc-reporting].
 
 [coc]: https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html
 [coc-reporting]: https://docs.carpentries.org/topic_folders/policies/incident-reporting.html


### PR DESCRIPTION
Suggesting changes to CoC reporting language. Since this isn't in a Carpentries repository, the reporting guidelines would just apply when it's a registered Carpentries workshop. Otherwise, The Carpentries wouldn't necessarily have any knowledge or control over what happened in this space. If you have some other reporting structure to include in other situations, you could put that here too.

## Checklist
- ~[ ] If you edited any files in `_episodes_rmd/`, run `make lesson-md`.~
- ~[ ] Run `make serve` locally to view the website and make sure the formatting renders correctly.~
- [x] The build-website workflow succeeds on your most recent commit.
