### PR TITLE
Fix URLs in bibtex entries

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -5,7 +5,7 @@
   year = {2016},
   month = sep,
   abstract = {Data Carpentry is a lesson program of The Carpentries that develops and provides data skills training to researchers.},
-  howpublished = {https://datacarpentry.org/blog/2016/09/formative-assessment},
+  howpublished = \url{https://datacarpentry.org/blog/2016/09/formative-assessment},
   journal = {Data Carpentry},
   language = {en}
 }
@@ -16,7 +16,7 @@
   year = {2020},
   month = jun,
   abstract = {Online workshop logistics and how learners would set up their screens if they only had a single monitor.},
-  howpublished = {https://carpentries.org/blog/2020/06/online-workshop-logistics-and\_screen-layouts/},
+  howpublished = \url{https://carpentries.org/blog/2020/06/online-workshop-logistics-and\_screen-layouts/},
   journal = {The Carpentries},
   language = {en}
 }
@@ -27,7 +27,7 @@
   year = {2017},
   month = jul,
   abstract = {A few years ago, I wrote a post Don't teach built-in plotting to beginners (teach ggplot2). I argued that ggplot2 was not an advanced approach meant for experts, but rather a suitable introduction to data visualization.},
-  howpublished = {http://varianceexplained.org/r/teach-tidyverse/},
+  howpublished = \url{http://varianceexplained.org/r/teach-tidyverse/},
   journal = {Variance Explained},
   language = {en}
 }
@@ -36,14 +36,14 @@
   title = {The {{Carpentries Handbook}}},
   author = {{The Carpentries}},
   year = {2018},
-  howpublished = {https://docs.carpentries.org/index.html}
+  howpublished = \url{https://docs.carpentries.org/index.html}
 }
 
 @misc{the_carpentries_live_2018,
   title = {Live {{Coding}} Is a {{Skill}}},
   author = {{The Carpentries}},
   year = {2018},
-  howpublished = {https://carpentries.github.io/instructor-training/14-live/\#sticky-notes},
+  howpublished = \url{https://carpentries.github.io/instructor-training/14-live/\#sticky-notes},
   journal = {Instructor Training},
   language = {en}
 }

--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -5,7 +5,7 @@
   year = {2016},
   month = sep,
   abstract = {Data Carpentry is a lesson program of The Carpentries that develops and provides data skills training to researchers.},
-  howpublished = \url{https://datacarpentry.org/blog/2016/09/formative-assessment},
+  howpublished = "\url{https://datacarpentry.org/blog/2016/09/formative-assessment}",
   journal = {Data Carpentry},
   language = {en}
 }
@@ -16,7 +16,7 @@
   year = {2020},
   month = jun,
   abstract = {Online workshop logistics and how learners would set up their screens if they only had a single monitor.},
-  howpublished = \url{https://carpentries.org/blog/2020/06/online-workshop-logistics-and\_screen-layouts/},
+  howpublished = "\url{https://carpentries.org/blog/2020/06/online-workshop-logistics-and\_screen-layouts/}",
   journal = {The Carpentries},
   language = {en}
 }
@@ -27,7 +27,7 @@
   year = {2017},
   month = jul,
   abstract = {A few years ago, I wrote a post Don't teach built-in plotting to beginners (teach ggplot2). I argued that ggplot2 was not an advanced approach meant for experts, but rather a suitable introduction to data visualization.},
-  howpublished = \url{http://varianceexplained.org/r/teach-tidyverse/},
+  howpublished = "\url{http://varianceexplained.org/r/teach-tidyverse/}",
   journal = {Variance Explained},
   language = {en}
 }
@@ -36,14 +36,14 @@
   title = {The {{Carpentries Handbook}}},
   author = {{The Carpentries}},
   year = {2018},
-  howpublished = \url{https://docs.carpentries.org/index.html}
+  howpublished = "\url{https://docs.carpentries.org/index.html}"
 }
 
 @misc{the_carpentries_live_2018,
   title = {Live {{Coding}} Is a {{Skill}}},
   author = {{The Carpentries}},
   year = {2018},
-  howpublished = \url{https://carpentries.github.io/instructor-training/14-live/\#sticky-notes},
+  howpublished = "\url{https://carpentries.github.io/instructor-training/14-live/\#sticky-notes}",
   journal = {Instructor Training},
   language = {en}
 }


### PR DESCRIPTION
https://github.com/openjournals/jose-reviews/issues/144#issuecomment-1003627447

All the URLs now turn into hyperlinks correctly and don't run past the page width:

![ref-urls-screenshot](https://user-images.githubusercontent.com/17768269/147865790-8d984079-f58f-49cf-9bb1-8b0b34657631.png)


## Checklist
- ~[ ] If you edited any files in `_episodes_rmd/`, run `make lesson-md`.~
- ~[ ] Run `make serve` locally to view the website and make sure the formatting renders correctly.~
- [x] The build-website workflow succeeds on your most recent commit.
