### PR TITLE
renv::dep error -> errors

### DIFF
--- a/bin/dependencies.R
+++ b/bin/dependencies.R
@@ -64,9 +64,9 @@ identify_dependencies <- function() {
 
   required_pkgs <- unique(c(
     ## Packages for episodes
-    renv::dependencies(eps, progress = FALSE, error = "ignored")$Package,
+    renv::dependencies(eps, progress = FALSE, errors = "ignored")$Package,
     ## Packages for tools
-    renv::dependencies(bin, progress = FALSE, error = "ignored")$Package
+    renv::dependencies(bin, progress = FALSE, errors = "ignored")$Package
   ))
 
   required_pkgs


### PR DESCRIPTION
## Change(s) made
- In bin/dependencies.R
- renv:dependencies(eps, progress = FALSE, error = "ignored") -> renv:dependencies(eps, progress = FALSE, **errors** = "ignored")

This was throwing an error when I ran make site on my own computer (Nov. 2023), not sure if it's due to differences in the version of renv? Worth checking on your own in case it's just a me thing.

## Checklist
- [ ] If you edited any files in `_episodes_rmd/`, run `make lesson-md`.
- [ ] Run `make serve` locally to view the website and make sure the formatting renders correctly.
- [ ] The build-website workflow succeeds on your most recent commit.
