### PR TITLE
Updated macOS instructions

### DIFF
--- a/_includes/install_instructions/git.html
+++ b/_includes/install_instructions/git.html
@@ -44,24 +44,21 @@ the text below accordingly.
       </article>
       <article role="tabpanel" class="tab-pane" id="git-macos">
         <p>
-          <strong>For macOS</strong>, install Git for Mac
-          by downloading and running the most recent "mavericks" installer from
-          <a href="http://sourceforge.net/projects/git-osx-installer/files/">this list</a>.
-          Because this installer is not signed by the developer, you may have to
-          right click (control click) on the .pkg file, click Open, and click
-          Open on the pop up window.
-          After installing Git, there will not be anything in your <code>/Applications</code> folder,
-          as Git is a command line program.
+          Please open the Terminal app, type <code>git --version</code> and press
+          <kbd>Enter</kbd>/<kbd>Return</kbd>. If it's not installed already,
+          follow the instructions to <code>Install</code> the "command line
+          developer tools". <strong>Do not click</strong> "Get Xcode", because that will
+          take too long and is not necessary for our Git lesson.
+          After installing these tools, there won't be anything in your <code>/Applications</code>
+          folder, as they and Git are command line programs.
           <strong>For older versions of OS X (10.5-10.8)</strong> use the
           most recent available installer labelled "snow-leopard"
           <a href="http://sourceforge.net/projects/git-osx-installer/files/">available here</a>.
+          (Note: this project is no longer maintained.)
+          Because this installer is not signed by the developer, you may have to
+          right click (control click) on the .pkg file, click Open, and click
+          Open in the pop-up dialog.
         </p>
-        <h4>Video Tutorial</h4>
-        <div class="yt-wrapper2">
-        <div class="yt-wrapper">
-          <iframe type="text/html" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" src="https://www.youtube-nocookie.com/embed/9LQhwETCdwY?modestbranding=1&playsinline=1&iv_load_policy=3&rel=0" class="yt-frame" allowfullscreen></iframe>
-        </div>
-        </div>
       </article>
       <article role="tabpanel" class="tab-pane" id="git-linux">
         <p>


### PR DESCRIPTION
## Issues
- Resolves outdated Git install instructions for MacOS .

## Change(s) made
- Inserted new instructions from Carpentries workshop template
-

## Checklist
- [ ] If you edited any files in `_episodes_rmd/`, run `make lesson-md`.
- [ ] Run `make serve` locally to view the website and make sure the formatting renders correctly.
- [ ] The build-website workflow succeeds on your most recent commit.
